### PR TITLE
Update to support React and Vue

### DIFF
--- a/keymaps/autoclose-html.cson
+++ b/keymaps/autoclose-html.cson
@@ -17,3 +17,9 @@
 
 'atom-text-editor[data-grammar~="gfm"]':
 	'>': 'autoclose-html-plus:close-and-complete'
+
+'atom-text-editor[data-grammar~="js"]':
+	'>': 'autoclose-html-plus:close-and-complete'
+	
+'atom-text-editor[data-grammar~="vue"]':
+	'>': 'autoclose-html-plus:close-and-complete'


### PR DESCRIPTION
Allow html closing tags in .js files (for React) and .vue (Vue)